### PR TITLE
feat(di): add optional injection and named multi instances

### DIFF
--- a/packages/di/readme.md
+++ b/packages/di/readme.md
@@ -125,6 +125,68 @@ if (isInjected(context, UserService)) {
 }
 ```
 
+### Dependency Declaration
+
+You can declare dependencies using the `deps` property. The injector will automatically sort providers to ensure dependencies are instantiated before the services that need them.
+
+```typescript
+import { provide, inject, Context, Providers, injector } from '@signe/di';
+
+const context = new Context();
+
+class DatabaseService {
+  connect() {
+    return 'Connected to database';
+  }
+}
+
+class UserRepository {
+  constructor(context: Context) {
+    this.db = inject(context, DatabaseService);
+  }
+  
+  static deps = [DatabaseService];
+}
+
+class UserService {
+  constructor(context: Context) {
+    this.repository = inject(context, UserRepository);
+  }
+  
+  static deps = [UserRepository];
+}
+
+const providers: Providers = [
+  UserService,
+  UserRepository,
+  DatabaseService
+];
+
+// The injector will automatically sort: DatabaseService -> UserRepository -> UserService
+await injector(context, providers);
+```
+
+You can also declare dependencies on provider objects:
+
+```typescript
+const providers: Providers = [
+  {
+    provide: 'API_CLIENT',
+    useFactory: (context) => {
+      const config = inject(context, 'CONFIG');
+      return new ApiClient(config);
+    },
+    deps: ['CONFIG']
+  },
+  {
+    provide: 'CONFIG',
+    useValue: { apiUrl: 'https://api.example.com' }
+  }
+];
+```
+
+**Note:** The injector will detect and throw an error if circular dependencies are found.
+
 ### Find Providers
 
 ```typescript

--- a/packages/di/src/inject.ts
+++ b/packages/di/src/inject.ts
@@ -3,64 +3,233 @@
  * @module @signe/di/inject
  */
 
-import { Provider, Providers } from "./types";
 import { Context } from "./context";
+import {
+  InjectionOptions,
+  InstanceLookupOptions,
+  ProvideOptions,
+  Provider,
+  ProviderToken,
+  Providers
+} from "./types";
+
+const DEFAULT_INSTANCE_KEY = "__default__";
+
+interface ProviderRecord {
+  multi: boolean;
+  values: Map<string, any>;
+  injected: Set<string>;
+}
+
+function toTokenName(token: ProviderToken | string): string {
+  return typeof token === "function" ? token.name : token;
+}
+
+function toInstanceKey(name?: string): string {
+  return name ?? DEFAULT_INSTANCE_KEY;
+}
+
+function getRecord(context: Context, token: ProviderToken | string): ProviderRecord | undefined {
+  return context.get("inject:" + toTokenName(token));
+}
+
+function ensureRecord(context: Context, token: ProviderToken | string): ProviderRecord {
+  const key = "inject:" + toTokenName(token);
+  let record = context.get(key) as ProviderRecord | undefined;
+  if (!record) {
+    record = {
+      multi: false,
+      values: new Map<string, any>(),
+      injected: new Set<string>()
+    };
+  }
+  context.set(key, record);
+  return record;
+}
 
 /**
  * Provides a value to the dependency injection context
  * @template T - Type of the value being provided
  * @param context - The injection context
- * @param name - Identifier for the provided value
+ * @param token - Identifier for the provided value
  * @param value - The value to provide
+ * @param options - Configuration options for the provided value
  * @returns The provided value
  */
-export function provide<T>(context: Context, name: string, value: T): T {
-  context.set("inject:" + name, value);
+export function provide<T>(
+  context: Context,
+  token: ProviderToken | string,
+  value: T,
+  options: ProvideOptions = {}
+): T {
+  const record = ensureRecord(context, token);
+  const instanceKey = toInstanceKey(options.name);
+
+  if (options.multi) {
+    record.multi = true;
+  }
+
+  if (!record.multi && instanceKey !== DEFAULT_INSTANCE_KEY) {
+    // If we are switching from single to named instance without multi, enable multi mode implicitly
+    record.multi = true;
+  }
+
+  record.values.set(instanceKey, value);
   return value;
 }
 
 /**
  * Checks if a service has been injected into the context
  * @param context - The injection context
- * @param name - Name of the service to check
+ * @param token - Token of the service to check
+ * @param options - Optional lookup configuration
  * @returns True if the service has been injected, false otherwise
  */
-export function isInjected(context: Context, name: string): boolean {
-  return context.get('injected:' + name) === true;
+export function isInjected(
+  context: Context,
+  token: ProviderToken | string,
+  options: InstanceLookupOptions = {}
+): boolean {
+  const record = getRecord(context, token);
+  if (!record) {
+    return false;
+  }
+
+  if (options.name) {
+    return record.injected.has(toInstanceKey(options.name));
+  }
+
+  if (record.multi) {
+    return record.injected.size > 0;
+  }
+
+  return record.injected.has(DEFAULT_INSTANCE_KEY);
 }
 
 /**
  * Checks if a service has been provided in the context
  * @param context - The injection context
- * @param name - Name of the service to check
+ * @param token - Token of the service to check
+ * @param options - Optional lookup configuration
  * @returns True if the service has been provided, false otherwise
  */
-export function isProvided(context: Context, name: string): boolean {
-  return context.get('inject:' + name) !== undefined;
+export function isProvided(
+  context: Context,
+  token: ProviderToken | string,
+  options: InstanceLookupOptions = {}
+): boolean {
+  const record = getRecord(context, token);
+  if (!record) {
+    return false;
+  }
+
+  if (options.name) {
+    return record.values.has(toInstanceKey(options.name));
+  }
+
+  if (record.multi) {
+    return record.values.size > 0;
+  }
+
+  return record.values.has(DEFAULT_INSTANCE_KEY);
 }
 
+/**
+ * Checks if an instance exists in the context
+ * @param context - The injection context
+ * @param token - Token of the service to check
+ * @param options - Optional lookup configuration
+ * @returns True if the instance exists, false otherwise
+ */
+export function hasInstance(
+  context: Context,
+  token: ProviderToken | string,
+  options: InstanceLookupOptions = {}
+): boolean {
+  return isProvided(context, token, options);
+}
+
+function handleMissingInjection(
+  token: ProviderToken | string,
+  options: InjectionOptions
+): never {
+  const name = toTokenName(token);
+  if (options.name) {
+    throw new Error(`Injection provider ${name} with name ${options.name} not found`);
+  }
+  throw new Error(`Injection provider ${name} not found`);
+}
+
+function markInjected(record: ProviderRecord, key: string) {
+  record.injected.add(key);
+}
+
+function markAllInjected(record: ProviderRecord) {
+  for (const key of record.values.keys()) {
+    record.injected.add(key);
+  }
+}
+
+export function inject<T>(context: Context, token: ProviderToken | string, options: InjectionOptions & { multi: true }): T[];
+export function inject<T>(context: Context, token: ProviderToken | string, options: InjectionOptions & { optional: true }): T | undefined;
+export function inject<T>(context: Context, token: ProviderToken | string, options?: InjectionOptions): T;
 /**
  * Retrieves a service from the dependency injection context
  * @template T - Type of the service to inject
  * @param context - The injection context
- * @param service - Class constructor or string identifier of the service
- * @param args - Optional arguments for service instantiation
- * @returns The injected service instance
+ * @param token - Class constructor or string identifier of the service
+ * @param options - Optional configuration for resolving the service
+ * @returns The injected service instance or `undefined` when optional
  * @throws {Error} If the requested service is not found in the context
  */
 export function inject<T>(
   context: Context,
-  service: (new (...args: any[]) => T) | string,
-  args: any[] = []
-): T {
-  const isClass = typeof service === "function";
-  const name = isClass ? service.name : service;
-  const value = context.get("inject:" + name);
-  if (value) {
-    context.set('injected:' + name, true)
+  token: ProviderToken | string,
+  options: InjectionOptions = {}
+): T | T[] | undefined {
+  const record = getRecord(context, token);
+
+  if (!record) {
+    if (options.optional) {
+      return options.multi ? [] : undefined;
+    }
+    return handleMissingInjection(token, options);
+  }
+
+  if (options.name) {
+    const instanceKey = toInstanceKey(options.name);
+    if (!record.values.has(instanceKey)) {
+      if (options.optional) {
+        return undefined;
+      }
+      return handleMissingInjection(token, options);
+    }
+    const value = record.values.get(instanceKey);
+    markInjected(record, instanceKey);
     return value as T;
   }
-  throw new Error(`Injection provider ${name} not found`);
+
+  if (options.multi || record.multi) {
+    if (record.values.size === 0) {
+      if (options.optional) {
+        return [];
+      }
+      return handleMissingInjection(token, options);
+    }
+    markAllInjected(record);
+    return Array.from(record.values.values()) as T[];
+  }
+
+  const value = record.values.get(DEFAULT_INSTANCE_KEY);
+  if (value === undefined) {
+    if (options.optional) {
+      return undefined;
+    }
+    return handleMissingInjection(token, options);
+  }
+
+  markInjected(record, DEFAULT_INSTANCE_KEY);
+  return value as T;
 }
 
 /**
@@ -89,7 +258,7 @@ export function override(
 
   // Flatten the providers array
   const flatProviders = providers.flat();
-  
+
   // Check if provider exists
   const exists = flatProviders.some(provider => {
     if (typeof provider === "function") {
@@ -127,7 +296,7 @@ export function override(
  */
 export function findProviders<T extends Provider = Provider>(providers: Providers, name: string | RegExp): T[] {
   const results: any[] = [];
-  
+
   for (const provider of providers) {
     if (Array.isArray(provider)) {
       // Recursively search in nested arrays and concat results
@@ -137,7 +306,7 @@ export function findProviders<T extends Provider = Provider>(providers: Provider
       results.push(provider as T);
     }
   }
-  
+
   return results;
 }
 
@@ -154,7 +323,7 @@ export function findProvider<T extends Provider = Provider>(providers: Providers
     if (typeof providers === "object" && 'provide' in providers) {
       const provider = providers as any
       const providerName = typeof provider.provide === "function"
-        ? provider.provide.name 
+        ? provider.provide.name
         : provider.provide;
 
       if (name instanceof RegExp) {
@@ -177,8 +346,8 @@ export function findProvider<T extends Provider = Provider>(providers: Providers
 
     // Check object provider
     if (typeof provider === "object" && 'provide' in provider) {
-      const providerName = typeof provider.provide === "function" 
-        ? provider.provide.name 
+      const providerName = typeof provider.provide === "function"
+        ? provider.provide.name
         : provider.provide;
 
       // Handle RegExp matching

--- a/packages/di/src/types.ts
+++ b/packages/di/src/types.ts
@@ -27,7 +27,54 @@ export interface ProviderMeta {
   [key: string]: any;
 }
 
-export interface ValueProvider {
+/**
+ * Common options available to all providers
+ */
+export interface ProviderOptions {
+  /**
+   * When true, allows multiple instances to be registered for the same token
+   */
+  multi?: boolean;
+  /**
+   * Optional name used to register and resolve a specific instance
+   */
+  name?: string;
+}
+
+/**
+ * Options that can be passed when calling {@link provide}
+ */
+export interface ProvideOptions extends ProviderOptions {}
+
+/**
+ * Options that can be passed when calling {@link inject}
+ */
+export interface InjectionOptions {
+  /**
+   * Optional name used to resolve a specific instance
+   */
+  name?: string;
+  /**
+   * When true, allows retrieving all instances registered with {@link ProviderOptions.multi}
+   */
+  multi?: boolean;
+  /**
+   * When true, `inject` will return `undefined` instead of throwing if the instance is missing
+   */
+  optional?: boolean;
+}
+
+/**
+ * Options used when checking if an instance exists in the context
+ */
+export interface InstanceLookupOptions {
+  /**
+   * Optional name of the instance to check
+   */
+  name?: string;
+}
+
+export interface ValueProvider extends ProviderOptions {
   /** Token to identify the provider */
   provide: ProviderToken;
   /** Value to be injected */
@@ -41,7 +88,7 @@ export interface ValueProvider {
 /**
  * Provider configuration for class-based injection
  */
-export interface ClassProvider {
+export interface ClassProvider extends ProviderOptions {
   /** Token to identify the provider */
   provide: ProviderToken;
   /** Class to be instantiated */
@@ -55,7 +102,7 @@ export interface ClassProvider {
 /**
  * Provider configuration for factory-based injection
  */
-export interface FactoryProvider {
+export interface FactoryProvider extends ProviderOptions {
   /** Token to identify the provider */
   provide: ProviderToken;
   /** Tokens that must be injected before this provider */
@@ -69,7 +116,7 @@ export interface FactoryProvider {
 /**
  * Provider configuration for alias-based injection
  */
-export interface ExistingProvider {
+export interface ExistingProvider extends ProviderOptions {
   /** Token to identify the provider */
   provide: ProviderToken;
   /** Token of the existing provider to use */


### PR DESCRIPTION
## Summary
- allow registering multiple named instances and optional injection lookups in the DI context
- expose richer provider metadata and new helpers for checking instance existence
- expand the DI test suite and documentation to cover multi-instance and optional scenarios

## Testing
- pnpm vitest run

------
https://chatgpt.com/codex/tasks/task_e_68ec941b6b5883219e8a520a94798ece