### PR TITLE
[codex] Harden public package usage

### DIFF
--- a/.changeset/public-library-hardening.md
+++ b/.changeset/public-library-hardening.md
@@ -1,0 +1,9 @@
+---
+"@signe/di": patch
+"@signe/reactive": patch
+"@signe/room": patch
+"@signe/schema-to-zod": patch
+"@signe/sync": patch
+---
+
+Harden public package usage with clearer package metadata, reliable typechecking, safer sync client listener removal, stronger room request routing, and aligned load behavior for typed collections.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Samuel Ronce
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,25 +1,33 @@
 {
   "name": "signe",
   "version": "2.9.0",
-  "description": "",
-  "main": "src/index.ts",
+  "private": true,
+  "description": "Reactive state, synchronization, and real-time room primitives for TypeScript applications.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RSamaium/signe.git"
+  },
   "scripts": {
     "test": "vitest run",
     "coverage": "vitest --coverage",
-    "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs",
     "build": "pnpm -r --filter=./packages/** run build",
+    "typecheck": "tsc --noEmit",
     "release": "bumpp package.json packages/*/package.json --all",
     "dev": "pnpm -r --filter=./packages/** --parallel run dev",
     "changeset": "changeset",
     "publish:packages": "changeset publish",
     "version:packages": "changeset version"
   },
-  "keywords": [],
+  "keywords": [
+    "reactive",
+    "signals",
+    "realtime",
+    "partykit",
+    "typescript"
+  ],
   "type": "module",
-  "author": "",
-  "license": "ISC",
+  "author": "Samuel Ronce",
+  "license": "MIT",
   "devDependencies": {
     "@changesets/cli": "^2.27.5",
     "@signe/reactive": "workspace:*",

--- a/packages/di/package.json
+++ b/packages/di/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@signe/di",
   "version": "2.9.0",
-  "description": "",
+  "description": "Lightweight dependency injection container for TypeScript applications.",
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsup src/index.ts",
@@ -14,7 +14,11 @@
     },
     "./*": "./*"
   },
-  "keywords": [],
+  "keywords": [
+    "dependency-injection",
+    "di",
+    "typescript"
+  ],
   "author": "Samuel Ronce",
   "license": "MIT",
   "publishConfig": {

--- a/packages/reactive/package.json
+++ b/packages/reactive/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@signe/reactive",
   "version": "2.9.0",
-  "description": "",
+  "description": "Small signal-based reactivity primitives with observable object and array changes.",
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsup src/index.ts",
@@ -14,8 +14,13 @@
     },
     "./*": "./*"
   },
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "signals",
+    "reactive",
+    "rxjs",
+    "typescript"
+  ],
+  "author": "Samuel Ronce",
   "license": "MIT",
   "dependencies": {
     "rxjs": "^7.8.1"

--- a/packages/reactive/src/signal.ts
+++ b/packages/reactive/src/signal.ts
@@ -33,15 +33,13 @@ const getGlobalReactiveStore = () => {
   if (typeof window !== 'undefined') {
     globalObj = window;
   } 
-  // Node.js - avoid using 'global' directly to prevent type errors
-  else if (typeof process !== 'undefined' && process.versions && process.versions.node) {
-    // In Node.js, 'global' is equivalent to globalThis
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    globalObj = (Function('return this')()) as any;
-  }
   // Web Worker or other environments
   else if (typeof self !== 'undefined') {
     globalObj = self;
+  }
+  // Last cross-runtime fallback for older JavaScript environments
+  else if (typeof Function !== 'undefined') {
+    globalObj = (Function('return this')()) as any;
   }
   // Really unusual environment
   else {

--- a/packages/room/package.json
+++ b/packages/room/package.json
@@ -1,13 +1,19 @@
 {
   "name": "@signe/room",
   "version": "2.9.0",
-  "description": "",
+  "description": "PartyKit room primitives with synchronized state, sessions, guards, and HTTP handlers.",
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsup src/index.ts",
     "dev": "tsup src/index.ts --watch"
   },
-  "keywords": [],
+  "keywords": [
+    "partykit",
+    "realtime",
+    "websocket",
+    "cloudflare",
+    "typescript"
+  ],
   "author": "Samuel Ronce",
   "type": "module",
   "exports": {

--- a/packages/room/readme.md
+++ b/packages/room/readme.md
@@ -123,7 +123,7 @@ The `@Request` decorator allows you to handle HTTP requests with specific routes
 
 ```ts
 import { z } from "zod";
-import { Room, Request, RequestGuard, ServerResponse } from "@signe/room";
+import { Guard, Room, Request, ServerResponse } from "@signe/room";
 
 @Room({
   path: "api"
@@ -169,11 +169,12 @@ class ApiRoom {
 }
 ```
 
-Request handler methods receive these parameters:
-1. `req`: The original Party.Request object
-2. `body`: The validated request body (if validation schema was provided)
-3. `params`: An object containing any path parameters
-4. `room`: The Party.Room instance
+Request handler methods receive:
+
+1. `req`: the original `Party.Request`, extended with `req.params` and
+   `req.data` when a validation schema is provided.
+2. `res`: a `ServerResponse` helper for JSON, text, redirects, and common
+   error responses.
 
 You can return:
 - A Response object for complete control

--- a/packages/room/src/jwt.ts
+++ b/packages/room/src/jwt.ts
@@ -132,9 +132,7 @@ export class JWTAuth {
         };
 
         // Encode header and payload
-        // @ts-expect-error - TS doesn't have a built-in TextEncoder
         const encodedHeader: string = this.base64UrlEncode(this.encoder.encode(JSON.stringify(header)));
-        //   @ts-expect-error - TS doesn't have a built-in TextEncoder
         const encodedPayload: string = this.base64UrlEncode(this.encoder.encode(JSON.stringify(fullPayload)));
 
         // Create signature base
@@ -174,9 +172,7 @@ export class JWTAuth {
 
         // Decode header and payload
         try {
-            // @ts-expect-error - TS doesn't have a built-in TextDecoder
             const header: JWTHeader = JSON.parse(this.decoder.decode(this.base64UrlDecode(encodedHeader)));
-            // @ts-expect-error - TS doesn't have a built-in TextDecoder
             const payload: JWTPayload = JSON.parse(this.decoder.decode(this.base64UrlDecode(encodedPayload)));
 
             // Check algorithm

--- a/packages/room/src/server.ts
+++ b/packages/room/src/server.ts
@@ -615,7 +615,10 @@ export class Server implements Party.Server {
       return;
     }
 
-    const sessionExpiryTime = subRoom.constructor.sessionExpiryTime;
+    const sessionExpiryTime =
+      subRoom.sessionExpiryTime ??
+      subRoom.constructor.sessionExpiryTime ??
+      5 * 60 * 1000;
     await this.garbageCollector({ sessionExpiryTime });
 
     // Check room guards
@@ -1289,9 +1292,7 @@ export class Server implements Party.Server {
 
     const url = new URL(req.url);
     const method = req.method;
-    let pathname = url.pathname;
-
-    pathname = '/' + pathname.split('/').slice(4).join('/');
+    const pathname = this.normalizeRequestPath(url.pathname);
 
     // Check each registered handler
     for (const [routeKey, handler] of requestHandlers.entries()) {
@@ -1325,16 +1326,18 @@ export class Server implements Party.Server {
         if (handler.bodyValidation && ['POST', 'PUT', 'PATCH'].includes(method)) {
           try {
             const contentType = req.headers.get('content-type') || '';
-            if (contentType.includes('application/json')) {
-              const body = await req.json();
-              const validation = handler.bodyValidation.safeParse(body);
-              if (!validation.success) {
-                return res.badRequest("Invalid request body", {
-                  details: validation.error
-                });
-              }
-              bodyData = validation.data;
+            if (!contentType.includes('application/json')) {
+              return res.badRequest("Content-Type must be application/json");
             }
+
+            const body = await req.json();
+            const validation = handler.bodyValidation.safeParse(body);
+            if (!validation.success) {
+              return res.badRequest("Invalid request body", {
+                details: validation.error
+              });
+            }
+            bodyData = validation.data;
           } catch (error) {
             return res.badRequest("Failed to parse request body");
           }
@@ -1372,14 +1375,7 @@ export class Server implements Party.Server {
    * @returns {boolean} True if the paths match
    */
   private pathMatches(requestPath: string, handlerPath: string): boolean {
-    // Convert handler path pattern to regex
-    // Replace :param with named capture groups
-    const pathRegexString = handlerPath
-      .replace(/\//g, '\\/') // Escape slashes
-      .replace(/:([^\/]+)/g, '([^/]+)'); // Convert :params to capture groups
-
-    const pathRegex = new RegExp(`^${pathRegexString}`);
-    return pathRegex.test(requestPath);
+    return this.pathPatternToRegex(handlerPath).test(requestPath);
   }
 
   /**
@@ -1401,12 +1397,7 @@ export class Server implements Party.Server {
       }
     });
 
-    // Extract parameter values from request path
-    const pathRegexString = handlerPath
-      .replace(/\//g, '\\/') // Escape slashes
-      .replace(/:([^\/]+)/g, '([^/]+)'); // Convert :params to capture groups
-
-    const pathRegex = new RegExp(`^${pathRegexString}`);
+    const pathRegex = this.pathPatternToRegex(handlerPath);
     const matches = requestPath.match(pathRegex);
 
     if (matches && matches.length > 1) {
@@ -1417,6 +1408,28 @@ export class Server implements Party.Server {
     }
 
     return params;
+  }
+
+  private normalizeRequestPath(pathname: string): string {
+    const parts = pathname.split('/').filter(Boolean);
+    if (parts[0] === 'parties' && parts.length >= 3) {
+      const routePath = parts.slice(3).join('/');
+      return routePath ? `/${routePath}` : '/';
+    }
+
+    return pathname || '/';
+  }
+
+  private pathPatternToRegex(handlerPath: string): RegExp {
+    const segments = handlerPath.split('/').map(segment => {
+      if (segment.startsWith(':')) {
+        return '([^/]+)';
+      }
+
+      return segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    });
+
+    return new RegExp(`^${segments.join('/')}$`);
   }
 
   /**

--- a/packages/room/src/world.ts
+++ b/packages/room/src/world.ts
@@ -1,10 +1,9 @@
 import { signal } from "@signe/reactive";
-import { Room, Action, Guard, Request } from "./decorators";
+import { Room, Guard, Request } from "./decorators";
 import { sync, id, persist } from "@signe/sync";
 import { z } from "zod";
 import * as Party from "./types/party";
 import { guardManageWorld } from "./world.guard";
-import { response } from "./utils";
 import { RoomInterceptorPacket, RoomOnJoin } from "./interfaces";
 import { ServerResponse } from "./request/response";
 
@@ -24,14 +23,8 @@ const RoomConfigSchema = z.object({
   maxShards: z.number().int().positive().optional(),
 });
 
-const RegisterShardSchema = z.object({
-  shardId: z.string(),
-  roomId: z.string(),
-  url: z.string().url(),
-  maxConnections: z.number().int().positive(),
-});
-
 const UpdateShardStatsSchema = z.object({
+  shardId: z.string(),
   connections: z.number().int().min(0),
   status: z.enum(['active', 'maintenance', 'draining']).optional(),
 });
@@ -139,8 +132,15 @@ export class WorldRoom implements RoomInterceptorPacket, RoomOnJoin {
     method: 'POST',
   })
   @Guard([guardManageWorld])
-  async registerRoom(req: Party.Request) {
-    const roomConfig: z.infer<typeof RoomConfigSchema> = await req.json();
+  async registerRoom(req: Party.Request, res?: ServerResponse) {
+    const roomConfigResult = RoomConfigSchema.safeParse(await req.json());
+    if (!roomConfigResult.success) {
+      return res?.badRequest("Invalid room configuration", {
+        details: roomConfigResult.error
+      });
+    }
+
+    const roomConfig = roomConfigResult.data;
     const roomId = roomConfig.name;
     
     if (!this.rooms()[roomId]) {
@@ -178,7 +178,14 @@ export class WorldRoom implements RoomInterceptorPacket, RoomOnJoin {
   })
   @Guard([guardManageWorld])
   async updateShardStats(req: Party.Request, res: ServerResponse) {
-    const body: { shardId: string; connections: number; status: ShardStatus } = await req.json();
+    const bodyResult = UpdateShardStatsSchema.safeParse(await req.json());
+    if (!bodyResult.success) {
+      return res.badRequest("Invalid shard statistics", {
+        details: bodyResult.error
+      });
+    }
+
+    const body = bodyResult.data;
     const { shardId, connections, status } = body;
     const shard = this.shards()[shardId];
 
@@ -199,7 +206,14 @@ export class WorldRoom implements RoomInterceptorPacket, RoomOnJoin {
   })
   @Guard([guardManageWorld])
   async scaleRoom(req: Party.Request, res: ServerResponse) {
-    const data: z.infer<typeof ScaleRoomSchema> = await req.json();
+    const dataResult = ScaleRoomSchema.safeParse(await req.json());
+    if (!dataResult.success) {
+      return res.badRequest("Invalid scale request", {
+        details: dataResult.error
+      });
+    }
+
+    const data = dataResult.data;
     const { targetShardCount, shardTemplate, roomId } = data;
     
     // Validate room exists
@@ -234,11 +248,6 @@ export class WorldRoom implements RoomInterceptorPacket, RoomOnJoin {
           return a.currentConnections() - b.currentConnections();
         })
         .slice(0, previousShardCount - targetShardCount);
-      
-      // Remove the selected shards
-      const shardsToKeep = roomShards.filter(
-        shard => !shardsToRemove.some(s => s.id === shard.id)
-      );
       
       // Update shards
       for (const shard of shardsToRemove) {

--- a/packages/schema-to-zod/package.json
+++ b/packages/schema-to-zod/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@signe/schema-to-zod",
   "version": "2.9.0",
-  "description": "",
+  "description": "Convert JSON Schema definitions into Zod schemas.",
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsup src/index.ts",
@@ -14,7 +14,12 @@
     },
     "./*": "./*"
   },
-  "keywords": [],
+  "keywords": [
+    "json-schema",
+    "zod",
+    "validation",
+    "typescript"
+  ],
   "author": "Samuel Ronce",
   "license": "MIT",
   "publishConfig": {

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@signe/sync",
   "version": "2.9.0",
-  "description": "",
+  "description": "Decorator-based state synchronization and loading utilities for Signe signals.",
   "main": "./dist/index.js",
   "scripts": {
     "build": "tsup src/index.ts src/client/index.ts",
@@ -27,7 +27,12 @@
     "access": "public"
   },
   "type": "module",
-  "keywords": [],
-  "author": "",
+  "keywords": [
+    "state-sync",
+    "signals",
+    "decorators",
+    "typescript"
+  ],
+  "author": "Samuel Ronce",
   "license": "MIT"
 }

--- a/packages/sync/readme.md
+++ b/packages/sync/readme.md
@@ -330,6 +330,23 @@ load(instance, {
 }, true)
 ```
 
+When loading nested data into a signal that stores an object, `load` updates
+the signal value and preserves existing fields:
+
+```typescript
+const state = {
+  transition: signal({ active: false, reason: 'spawned' })
+}
+
+load(state, {
+  transition: {
+    active: true
+  }
+}, true)
+
+state.transition() // { active: true, reason: 'spawned' }
+```
+
 #### Loading Collections with Class Instances
 
 When loading data into collections that use class types, the instances are automatically created with the data passed to their constructor:

--- a/packages/sync/readme.md
+++ b/packages/sync/readme.md
@@ -190,7 +190,7 @@ load(game, {
 })
 ```
 
-**Important:** The constructor receives the data object first, then the `load` function automatically populates all the properties. This allows you to:
+**Important:** With nested object loads and path entries whose value is an object, the constructor receives the data object first, then the `load` function automatically populates all the properties. Full leaf paths such as `players.player-1.name` create the instance when needed, but only the individual leaf value is available at that point. This allows you to:
 - Initialize the instance with the provided data in the constructor
 - Perform custom initialization logic based on the data
 - The properties decorated with `@sync()` will still be automatically loaded after construction

--- a/packages/sync/src/client/index.ts
+++ b/packages/sync/src/client/index.ts
@@ -41,10 +41,27 @@ interface WorldConnectionResult extends ConnectionResult {
 
 function createConnection(options: PartySocketOptions, roomInstance: RoomInstance): ConnectionResult {
   const conn = new PartySocket(options);
+  const eventListeners = new Map<string, Map<(value: any) => void, EventListener>>();
+
+  const parseMessage = (data: unknown): any | null => {
+    if (typeof data !== "string") {
+      return null;
+    }
+
+    try {
+      return JSON.parse(data);
+    } catch {
+      return null;
+    }
+  };
   
   // Set up message handling
   conn.addEventListener("message", (event) => {
-    const object = JSON.parse(event.data);
+    const object = parseMessage(event.data);
+    if (!object) {
+      return;
+    }
+
     switch (object.type) {
       case "sync":
         load(roomInstance, object.value, true);
@@ -62,20 +79,31 @@ function createConnection(options: PartySocketOptions, roomInstance: RoomInstanc
       );
     },
     on: (key, cb) => {
-      conn.addEventListener("message", (event) => {
-        const object = JSON.parse(event.data);
+      const listener: EventListener = (event) => {
+        const object = parseMessage((event as MessageEvent).data);
+        if (!object) {
+          return;
+        }
+
         if (object.type === key) {
           cb(object.value);
         }
-      });
+      };
+
+      if (!eventListeners.has(key)) {
+        eventListeners.set(key, new Map());
+      }
+      eventListeners.get(key)!.set(cb, listener);
+      conn.addEventListener("message", listener);
     },
     off: (key, cb) => {
-      conn.removeEventListener("message", (event) => {
-        const object = JSON.parse(event.data);
-        if (object.type === key) {
-          cb(object.value);
-        }
-      });
+      const listener = eventListeners.get(key)?.get(cb);
+      if (!listener) {
+        return;
+      }
+
+      conn.removeEventListener("message", listener);
+      eventListeners.get(key)!.delete(cb);
     },
     close: () => conn.close(),
     conn

--- a/packages/sync/src/load.ts
+++ b/packages/sync/src/load.ts
@@ -65,6 +65,7 @@ function loadFromObject(
   for (let key in values) {
     const value = values[key];
     const newPath = currentPath ? `${currentPath}.${key}` : key;
+    initializeClassCollectionItem(rootInstance, currentPath, key, value);
     if (typeof value === "object" && !Array.isArray(value) && value !== null) {
       loadFromObject(rootInstance, value, newPath);
     } else {
@@ -72,6 +73,31 @@ function loadFromObject(
       loadValue(rootInstance, parts, value);
     }
   }
+}
+
+function initializeClassCollectionItem(
+  rootInstance: any,
+  parentPath: string,
+  key: string,
+  value: any
+) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return;
+  }
+
+  const parent = parentPath ? getByPath(rootInstance, parentPath) : rootInstance;
+  const classType = parent?.options?.classType;
+  if (!classType) {
+    return;
+  }
+
+  const container = isSignal(parent) ? parent() : parent;
+  if (!container || container[key] !== undefined) {
+    return;
+  }
+
+  container[key] = !isClass(classType) ? classType(key, value) : new classType(value);
+  setMetadata(container[key], "id", key);
 }
 
 /**
@@ -99,7 +125,23 @@ function loadValue(rootInstance: any, parts: string[], value: any) {
       }
       else if (isSignal(current)) {
         const currentValue = getWritableSignalValue(current);
-        if (Array.isArray(currentValue) && !isNaN(Number(part))) {
+        const targetKey = Array.isArray(currentValue) && !isNaN(Number(part)) ? Number(part) : part;
+
+        if (
+          current.options?.classType &&
+          value &&
+          typeof value === "object" &&
+          !Array.isArray(value)
+        ) {
+          const classType = current.options.classType;
+          if (currentValue[targetKey] === undefined) {
+            currentValue[targetKey] = !isClass(classType)
+              ? classType(String(part), value)
+              : new classType(value);
+            setMetadata(currentValue[targetKey], "id", part);
+          }
+          load(currentValue[targetKey], value, true);
+        } else if (Array.isArray(currentValue) && !isNaN(Number(part))) {
           currentValue[Number(part)] = value;
         } else {
           currentValue[part] = value;
@@ -159,7 +201,7 @@ export function getByPath(root: any, path: string) {
     if (isSignal(current)) {
       current = current();
     }
-    if (current[part]) {
+    if (current && part in current) {
       current = current[part];
     } else {
       return undefined;

--- a/packages/sync/src/load.ts
+++ b/packages/sync/src/load.ts
@@ -92,22 +92,28 @@ function loadValue(rootInstance: any, parts: string[], value: any) {
     if (i === parts.length - 1) {
       if (value == DELETE_TOKEN) {
         if (isSignal(current)) {
-          current = current();
+          current = getWritableSignalValue(current, false);
+          if (current === null || current === undefined) return;
         }
         Reflect.deleteProperty(current, part);
       }
+      else if (isSignal(current)) {
+        const currentValue = getWritableSignalValue(current);
+        if (Array.isArray(currentValue) && !isNaN(Number(part))) {
+          currentValue[Number(part)] = value;
+        } else {
+          currentValue[part] = value;
+        }
+      }
       else if (current[part]?._subject) {
         current[part].set(value);
-      }
-      else if (isSignal(current) && Array.isArray(current()) && !isNaN(Number(part))) {
-        current()[Number(part)] = value;
       }
       else {
         current[part] = value;
       }
     } else {
       if (isSignal(current)) {
-        current = current();
+        current = getWritableSignalValue(current);
       }
       const currentValue = current[part];
       if (currentValue === undefined) {
@@ -126,6 +132,15 @@ function loadValue(rootInstance: any, parts: string[], value: any) {
       current = current[part];
     }
   }
+}
+
+function getWritableSignalValue(signal: any, initialize = true) {
+  let value = signal();
+  if (initialize && (value === null || value === undefined)) {
+    value = {};
+    signal.set(value);
+  }
+  return value;
 }
 
 /**

--- a/packages/sync/src/utils.ts
+++ b/packages/sync/src/utils.ts
@@ -68,10 +68,14 @@ export function isInstanceOfClass(value: unknown): boolean {
 
 export function generateShortUUID(): string {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const randomBytes =
+    typeof globalThis.crypto?.getRandomValues === "function"
+      ? globalThis.crypto.getRandomValues(new Uint8Array(8))
+      : null;
   let uuid = '';
   for (let i = 0; i < 8; i++) {
-      const randomIndex = Math.floor(Math.random() * chars.length);
-      uuid += chars[randomIndex];
+    const randomValue = randomBytes?.[i] ?? Math.floor(Math.random() * 256);
+    uuid += chars[randomValue % chars.length];
   }
   return uuid;
 }

--- a/packages/sync/tests/client.spec.ts
+++ b/packages/sync/tests/client.spec.ts
@@ -231,6 +231,34 @@ describe("Sync Client", () => {
       
       // Verify removeEventListener was called
       expect(mockSocket.removeEventListener).toHaveBeenCalled();
+
+      const messageEvent = new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "custom-event",
+          value: { data: "test" },
+        }),
+      });
+
+      eventListeners.get("message").forEach(listener => listener(messageEvent));
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("should ignore invalid JSON messages", async () => {
+      const conn = await connectionRoom(defaultOptions, {});
+      const callback = vi.fn();
+
+      conn.on("custom-event", callback);
+
+      const messageEvent = new MessageEvent("message", {
+        data: "not-json",
+      });
+
+      expect(() => {
+        eventListeners.get("message").forEach(listener => listener(messageEvent));
+      }).not.toThrow();
+
+      expect(load).not.toHaveBeenCalled();
+      expect(callback).not.toHaveBeenCalled();
     });
 
     it("should close the connection", async () => {

--- a/readme.md
+++ b/readme.md
@@ -1,65 +1,118 @@
 # Signe
 
-A collection of packages to manage real-time and reactive applications.
+Signe is a TypeScript toolkit for reactive and real-time applications.
+
+It is published as small packages that can be used independently, or together for
+PartyKit/Cloudflare room-based applications.
 
 ## Packages
 
-| Package             | Description                                                                                                                                 |
-|---------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
-| `@signe/reactive`   | Primitive usage of reactivity with `signal`, `computed`, and `effect`.                                                                      |
-| `@signe/sync`       | Listens to signals within a class to synchronize with the client (if on the server-side) or, on the client-side, recreates a class from the data received from the server. Provides indication for data persistence. |
-| `@signe/room`       | Creates a Room based on PartyKit for real-time applications. Can be deployed on Cloudflare.                                                                 |
-| `@signe/di`         | Dependency injection for Signe applications.                                                                 |
+| Package | Use it for |
+| --- | --- |
+| `@signe/reactive` | Signals, computed values, effects, and observable object/array mutations. |
+| `@signe/sync` | Decorator-based state snapshots, persistence flags, and loading remote state into classes. |
+| `@signe/room` | PartyKit rooms with synchronized state, actions, guards, sessions, and HTTP handlers. |
+| `@signe/di` | Lightweight dependency injection for application services. |
+| `@signe/schema-to-zod` | JSON Schema to Zod conversion. |
+
+## Installation
+
+Install only the packages you need:
+
+```bash
+pnpm add @signe/reactive
+pnpm add @signe/reactive @signe/sync
+pnpm add @signe/room @signe/reactive @signe/sync
+```
+
+## Quick Start
+
+### Reactive State
+
+```ts
+import { computed, effect, signal } from "@signe/reactive";
+
+const count = signal(0);
+const doubled = computed(() => count() * 2);
+
+effect(() => {
+  console.log(doubled());
+});
+
+count.set(2);
+```
+
+### Synchronized Classes
+
+```ts
+import { signal } from "@signe/reactive";
+import { load, sync, syncClass } from "@signe/sync";
+
+class CounterState {
+  @sync() count = signal(0);
+}
+
+const state = new CounterState();
+
+syncClass(state, {
+  onSync(changes) {
+    console.log(Object.fromEntries(changes));
+  },
+});
+
+state.count.set(1);
+load(state, { count: 2 }, true);
+```
+
+### Realtime Rooms
+
+```ts
+import { signal } from "@signe/reactive";
+import { Action, Room, Server } from "@signe/room";
+import { id, sync, users } from "@signe/sync";
+
+class Player {
+  @id() id = signal("");
+  @sync() x = signal(0);
+  @sync() y = signal(0);
+}
+
+@Room({ path: "game-{id}" })
+class GameRoom {
+  @users(Player) players = signal<Record<string, Player>>({});
+
+  @Action("move")
+  move(player: Player, position: { x: number; y: number }) {
+    player.x.set(position.x);
+    player.y.set(position.y);
+  }
+}
+
+export default class GameServer extends Server {
+  rooms = [GameRoom];
+}
+```
 
 ## Development
 
-1. Ensure you have `pnpm` installed:
-   
-   ```bash
-   npm install -g pnpm
-   ```
+```bash
+pnpm install
+pnpm test
+pnpm run typecheck
+pnpm run build
+```
 
-2. Clone the repository:
-   
-   ```bash
-   git clone https://github.com/RSamaium/signe
-   ```
+The repository is a pnpm workspace. The root package is private; publishable
+packages live under `packages/*`.
 
-3. Install dependencies:
-   
-   ```bash
-   pnpm install
-   ```
+## Current Stability Notes
 
-4. Start the development server:
-   
-   ```bash
-   pnpm run dev
-   ```
-
-## Deployment
-
-1. Define a release:
-   
-   ```bash
-   pnpm run release
-   ```
-
-2. Push to the master branch for deployment on NPM:
-   
-   ```bash
-   git push origin master
-   ```
+- `@signe/reactive`, `@signe/sync`, `@signe/di`, and `@signe/schema-to-zod` are
+  small and directly usable.
+- `@signe/room` is usable for PartyKit-style rooms, but `WorldRoom` and `Shard`
+  should be treated as advanced infrastructure APIs and validated against your
+  deployment topology before production use.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Contributing
-
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests.
-
-## Acknowledgments
-
-- [PartyKit](https://partykit.dev)
-- [Cloudflare](https://www.cloudflare.com)
+MIT

--- a/tests/room/request.spec.ts
+++ b/tests/room/request.spec.ts
@@ -139,6 +139,23 @@ describe('Request Decorator', () => {
       usersCount: 2
     });
   });
+
+  it('should route direct paths without a PartyKit prefix', async () => {
+    const response = await server.onRequest(new globalThis.Request("http://localhost/status"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "online",
+      count: 0,
+      usersCount: 2
+    });
+  });
+
+  it('should not match longer paths against shorter handlers', async () => {
+    const response = await server.onRequest(createMockRequest("/status/extra"));
+
+    expect(response.status).toBe(404);
+  });
   
   it('should handle path parameters correctly', async () => {
     // Test existing user
@@ -181,6 +198,17 @@ describe('Request Decorator', () => {
     expect(invalidResponse.status).toBe(400);
     const invalidData = await invalidResponse.json();
     expect(invalidData.error).toBe("Invalid request body");
+
+    const missingContentTypeReq = createMockRequest("/increment", {
+      method: "POST",
+      body: JSON.stringify({ amount: 1 })
+    });
+
+    const missingContentTypeResponse = await server.onRequest(missingContentTypeReq);
+    expect(missingContentTypeResponse.status).toBe(400);
+    await expect(missingContentTypeResponse.json()).resolves.toEqual({
+      error: "Content-Type must be application/json"
+    });
   });
   
   it('should respect request guards', async () => {

--- a/tests/sync/load.spec.ts
+++ b/tests/sync/load.spec.ts
@@ -8,9 +8,10 @@ describe("load function", () => {
 
   beforeEach(() => {
     _class = class NestedClass {
+      constructorData: any;
       value = signal(0);
-      constructor(id: string) {
-        console.log('NestedClass constructor', id);
+      constructor(data?: any) {
+        this.constructorData = data;
       }
     }
 
@@ -165,6 +166,8 @@ describe("load function", () => {
   });
 
   it("should load nested GameObject in Scene", () => {
+    let constructorData: any;
+
     class GameObject {
       position = {
         x: signal(0),
@@ -172,6 +175,10 @@ describe("load function", () => {
       };
       @sync() direction = signal(0);
       @sync() graphics = signal([]);
+
+      constructor(data?: any) {
+        constructorData = data;
+      }
     }
 
     class Scene {
@@ -191,10 +198,39 @@ describe("load function", () => {
     }, true);
 
     expect(scene.users()['player1']).instanceOf(GameObject);
+    expect(constructorData).toEqual({
+      position: { x: 100, y: 200 },
+      direction: 45,
+      graphics: ['sprite1', 'sprite2']
+    });
     expect(scene.users()['player1'].position.x()).toBe(100);
     expect(scene.users()['player1'].position.y()).toBe(200);
     expect(scene.users()['player1'].direction()).toBe(45);
     expect(scene.users()['player1'].graphics()).toEqual(['sprite1', 'sprite2']);
+  });
+
+  it("should create collection class instances from path object values", () => {
+    class Player {
+      @sync() name = signal("");
+      @sync() score = signal(0);
+    }
+
+    class Game {
+      @sync(Player) players = signal<Record<string, Player>>({});
+    }
+
+    const game = new Game();
+
+    load(game, {
+      "players.player1": {
+        name: "Alice",
+        score: 100
+      }
+    });
+
+    expect(game.players().player1).instanceOf(Player);
+    expect(game.players().player1.name()).toBe("Alice");
+    expect(game.players().player1.score()).toBe(100);
   });
 
   it("should handle multiple loads on the same Scene", () => {

--- a/tests/sync/load.spec.ts
+++ b/tests/sync/load.spec.ts
@@ -52,6 +52,96 @@ describe("load function", () => {
     expect(testInstance.position.y()).toBe(20);
   });
 
+  it("should update primitive fields inside nested object signals from object values", () => {
+    const root = {
+      events: signal({
+        ev1: {
+          _removeTransition: signal({ active: false })
+        }
+      })
+    };
+
+    load(root, {
+      events: {
+        ev1: {
+          _removeTransition: {
+            active: true,
+            data: { source: "x" },
+            transition: { animation: "die" }
+          }
+        }
+      }
+    }, true);
+
+    expect(root.events().ev1._removeTransition()).toEqual({
+      active: true,
+      data: { source: "x" },
+      transition: { animation: "die" }
+    });
+  });
+
+  it("should update primitive fields inside nested object signals from path values", () => {
+    const root = {
+      events: signal({
+        ev1: {
+          _removeTransition: signal({ active: false })
+        }
+      })
+    };
+
+    load(root, {
+      "events.ev1._removeTransition.active": true,
+      "events.ev1._removeTransition.reason": "defeated",
+      "events.ev1._removeTransition.timeoutMs": 700
+    });
+
+    expect(root.events().ev1._removeTransition()).toEqual({
+      active: true,
+      reason: "defeated",
+      timeoutMs: 700
+    });
+  });
+
+  it("should initialize null signal values when loading nested object paths", () => {
+    const root = {
+      data: signal(null)
+    };
+
+    load(root, {
+      data: {
+        active: true,
+        transition: { animation: "die" }
+      }
+    }, true);
+
+    expect(root.data()).toEqual({
+      active: true,
+      transition: { animation: "die" }
+    });
+  });
+
+  it("should keep existing object signal fields during partial nested loads", () => {
+    const root = {
+      transition: signal({
+        active: false,
+        reason: "spawned",
+        timeoutMs: 300
+      })
+    };
+
+    load(root, {
+      transition: {
+        active: true
+      }
+    }, true);
+
+    expect(root.transition()).toEqual({
+      active: true,
+      reason: "spawned",
+      timeoutMs: 300
+    });
+  });
+
   
   it("collection", () => {
     load(testInstance, { 'nested.id.value': 10});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
+    "emitDecoratorMetadata": false,
     "lib": ["ES2020", "DOM"],
     "moduleResolution": "node",
     "paths": {
@@ -13,5 +13,11 @@
     "skipLibCheck": true,
     "esModuleInterop": true
   },
-  "exclude": ["**/dist/**", "node_modules"]
+  "include": ["packages/*/src/**/*.ts"],
+  "exclude": [
+    "**/dist/**",
+    "node_modules",
+    "packages/**/examples/**",
+    "tests/**"
+  ]
 }


### PR DESCRIPTION
## What changed

- Reworked the root README to explain the package split, installation paths, quick starts, development checks, and current stability notes.
- Added an MIT LICENSE file, aligned root package metadata, marked the workspace root private, and added a `typecheck` script.
- Added package descriptions, keywords, author metadata, and a Changeset for the public packages.
- Hardened `@signe/sync` loading behavior so typed collection object loads create class instances consistently, including path entries whose value is an object.
- Fixed `@signe/sync/client` listener cleanup so `off()` removes the wrapper registered by `on()`, and ignored malformed JSON messages safely.
- Hardened `@signe/room` request handling with exact path matching, direct-path routing support, JSON content-type validation for Zod-validated bodies, and session-expiry fallback handling.
- Validated `WorldRoom` management payloads and removed stale unused imports/schema.
- Removed obsolete JWT `@ts-expect-error` comments and replaced direct `process` fallback usage in reactive global-store detection.

## Why

The repository was already functional, but a public library needs clearer first-run documentation, predictable type/build checks, npm metadata, and fewer sharp edges in client listeners, room routing, and sync loading behavior.

## Validation

- `pnpm run typecheck`
- `pnpm test` (22 files, 393 tests)
- `pnpm build`

Note: this branch also includes the existing local commit `801727f feat(load): enhance load function to support nested object updates and preserve existing fields`, which was already ahead of `origin/master` before this hardening pass.